### PR TITLE
Exclude DisallowSpacingIndent

### DIFF
--- a/HydraWiki/ruleset.xml
+++ b/HydraWiki/ruleset.xml
@@ -5,6 +5,7 @@
 	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
         <exclude name="MediaWiki.WhiteSpace.SpaceyParenthesis" />
 		<exclude name="MediaWiki.Commenting.LicenseComment" />
+		<exclude name="Generic.WhiteSpace.DisallowSpaceIndent" />
     </rule>
 	<!-- MediaWiki Adjustments -->
 	<rule ref="MediaWiki.NamingConventions.PrefixedGlobalFunctions">

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">= 7.1",
         "composer/semver": "1.4.2",
-        "mediawiki/mediawiki-codesniffer": "21.0.0"
+        "mediawiki/mediawiki-codesniffer": "22.0.0"
     },
     "require-dev": {
         "jakub-onderka/php-parallel-lint": "1.0.0",


### PR DESCRIPTION
Exclude DisallowSpacingIndent. It conflicts with FunctionCallSignature.OpeningIndent.

Update mediawiki-codesniffer to 22.0.0