### PR TITLE
Switch to Squiz standards for comment formatting

### DIFF
--- a/HydraWiki/Sniffs/Arrays/NoExtraSpacesSingleLineSniff.php
+++ b/HydraWiki/Sniffs/Arrays/NoExtraSpacesSingleLineSniff.php
@@ -16,6 +16,7 @@
 
 namespace HydraWiki\Sniffs\Arrays;
 
+use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\AbstractArraySniff;
 
 class NoExtraSpacesSingleLineSniff extends AbstractArraySniff {
@@ -30,11 +31,11 @@ class NoExtraSpacesSingleLineSniff extends AbstractArraySniff {
 	/**
 	 * Processes a single-line array definition.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The current file being checked.
-	 * @param int $stackPtr The position of the current token in the stack passed in $tokens.
-	 * @param int $arrayStart The token that starts the array definition.
-	 * @param int $arrayEnd The token that ends the array definition.
-	 * @param array $indices An array of token positions for the array keys, double arrows, and values.
+	 * @param File    $phpcsFile  The current file being checked.
+	 * @param integer $stackPtr   The position of the current token in the stack passed in $tokens.
+	 * @param integer $arrayStart The token that starts the array definition.
+	 * @param integer $arrayEnd   The token that ends the array definition.
+	 * @param array   $indices    An array of token positions for the array keys, double arrows, and values.
 	 *
 	 * @return void
 	 */
@@ -46,11 +47,11 @@ class NoExtraSpacesSingleLineSniff extends AbstractArraySniff {
 	/**
 	 * Processes a multi-line array definition.
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The current file being checked.
-	 * @param int $stackPtr The position of the current token in the stack passed in $tokens.
-	 * @param int $arrayStart The token that starts the array definition.
-	 * @param int $arrayEnd The token that ends the array definition.
-	 * @param array $indices An array of token positions for the array keys, double arrows, and values.
+	 * @param File    $phpcsFile  The current file being checked.
+	 * @param integer $stackPtr   The position of the current token in the stack passed in $tokens.
+	 * @param integer $arrayStart The token that starts the array definition.
+	 * @param integer $arrayEnd   The token that ends the array definition.
+	 * @param array   $indices    An array of token positions for the array keys, double arrows, and values.
 	 *
 	 * @return void
 	 */
@@ -61,8 +62,9 @@ class NoExtraSpacesSingleLineSniff extends AbstractArraySniff {
 	/**
 	 * Process the starting brace of a short array
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile
-	 * @param int $arrayStart
+	 * @param File    $phpcsFile
+	 * @param integer $arrayStart
+	 *
 	 * @return void
 	 */
 	private function handleArrayStart($phpcsFile, $arrayStart) {
@@ -84,8 +86,9 @@ class NoExtraSpacesSingleLineSniff extends AbstractArraySniff {
 	/**
 	 * Process the closing brace of a short array
 	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile
-	 * @param int $arrayEnd
+	 * @param File    $phpcsFile
+	 * @param integer $arrayEnd
+	 *
 	 * @return void
 	 */
 	private function handleArrayEnd($phpcsFile, $arrayEnd) {

--- a/HydraWiki/Sniffs/Commenting/LicenseCommentSniff.php
+++ b/HydraWiki/Sniffs/Commenting/LicenseCommentSniff.php
@@ -7,11 +7,11 @@
  * File: MediaWiki/Sniffs/Commenting/LicenseCommentSniff.php
  * From repository: https://github.com/wikimedia/mediawiki-tools-codesniffer
  *
- * @package	HydraWiki
- * @author Dieser Benutzer
- * @author Samuel Hilson <shhilson@curse.com>
+ * @package   HydraWiki
+ * @author    Dieser Benutzer
+ * @author    Samuel Hilson <shhilson@curse.com>
  * @copyright https://github.com/wikimedia/mediawiki-tools-codesniffer/blob/master/COPYRIGHT
- * @license https://github.com/wikimedia/mediawiki-tools-codesniffer/blob/master/LICENSE GPL-2.0-or-later
+ * @license   https://github.com/wikimedia/mediawiki-tools-codesniffer/blob/master/LICENSE GPL-2.0-or-later
  */
 namespace HydraWiki\Sniffs\Commenting;
 
@@ -20,12 +20,32 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
 class LicenseCommentSniff implements Sniff {
-
+	/**
+	 * Container for File class
+	 *
+	 * @var File
+	 */
 	private $file;
+
+	/**
+	 * Container for tokens array
+	 *
+	 * @var array
+	 */
 	private $tokens;
+
+	/**
+	 * End pointer
+	 *
+	 * @var integer
+	 */
 	private $end;
 
-	/** @var SpdxLicenses */
+	/**
+	 * Container for SpdxLicense class
+	 *
+	 * @var SpdxLicenses
+	 */
 	private $spdx = null;
 
 	/**
@@ -51,9 +71,10 @@ class LicenseCommentSniff implements Sniff {
 	/**
 	 * Initialize
 	 *
-	 * @param File $phpcsFile
-	 * @param int $stackPtr
+	 * @param File              $phpcsFile
+	 * @param integer           $stackPtr
 	 * @param SpdxLicenses|null $spdx
+	 *
 	 * @return void
 	 */
 	public function initialize(File $phpcsFile, $stackPtr, SpdxLicenses $spdx = null) {
@@ -68,8 +89,9 @@ class LicenseCommentSniff implements Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param File $phpcsFile The file being scanned.
-	 * @param int $stackPtr The position of the current token in the stack passed in $tokens.
+	 * @param File    $phpcsFile The file being scanned.
+	 * @param integer $stackPtr  The position of the current token in the stack passed in $tokens.
+	 *
 	 * @return void
 	 */
 	public function process(File $phpcsFile, $stackPtr) {
@@ -81,10 +103,11 @@ class LicenseCommentSniff implements Sniff {
 	}
 
 	/**
-	 * handle a single doc line
+	 * Handle a single doc line
 	 *
 	 * @param string $tag
-	 * @return mixed
+	 *
+	 * @return void
 	 */
 	private function processDocTag($tag) {
 		if ($this->isCorrectTag($tag)) {
@@ -119,7 +142,7 @@ class LicenseCommentSniff implements Sniff {
 	}
 
 	/**
-	 * get or initialize SpdxLicenses library
+	 * Get or initialize SpdxLicenses library
 	 *
 	 * @return SpdxLicenses
 	 */
@@ -131,15 +154,16 @@ class LicenseCommentSniff implements Sniff {
 	}
 
 	/**
-	 * normalize license text
+	 * Normalize license text
 	 *
 	 * @param string $next
+	 *
 	 * @return string
 	 */
 	private function getLicenseFromTag($next) {
 		$license = $this->tokens[$next]['content'];
 
-		// license can contain a url, use the text behind it
+		// License can contain a url, use the text behind it
 		if (preg_match('/^https?:\/\/[^\s]+\s+(.*)/', $license, $match)) {
 			$license = $match[1];
 		}
@@ -147,9 +171,10 @@ class LicenseCommentSniff implements Sniff {
 	}
 
 	/**
-	 * check if we are on the correct license tag
+	 * Check if we are on the correct license tag
 	 *
 	 * @param string $tag
+	 *
 	 * @return boolean
 	 */
 	private function isCorrectTag($tag) {
@@ -174,10 +199,11 @@ class LicenseCommentSniff implements Sniff {
 	}
 
 	/**
-	 * check the tag location is in file level doc comment
+	 * Check the tag location is in file level doc comment
 	 *
 	 * @param string $tag
-	 * @return boolean
+	 *
+	 * @return void
 	 */
 	private function isValidTagLocation($tag) {
 		if ($this->tokens[$tag]['level'] !== 0) {
@@ -190,10 +216,11 @@ class LicenseCommentSniff implements Sniff {
 	}
 
 	/**
-	 * check that tag has some text after @license
+	 * Check that tag has some text after @license
 	 *
 	 * @param string $tag
 	 * @param string $next
+	 *
 	 * @return boolean
 	 */
 	private function hasTextAfterTag($tag, $next) {
@@ -208,9 +235,10 @@ class LicenseCommentSniff implements Sniff {
 	}
 
 	/**
-	 * check for a private license
+	 * Check for a private license
 	 *
 	 * @param string $license
+	 *
 	 * @return boolean
 	 */
 	private function isValidProprietaryLicense($license) {
@@ -220,10 +248,11 @@ class LicenseCommentSniff implements Sniff {
 	}
 
 	/**
-	 * check if the license is marked as deprecated
+	 * Check if the license is marked as deprecated
 	 *
 	 * @param string $tag
 	 * @param string $license
+	 *
 	 * @return boolean
 	 */
 	private function isLicenseDeprecated($tag, $license) {
@@ -244,12 +273,13 @@ class LicenseCommentSniff implements Sniff {
 	}
 
 	/**
-	 * checks that the license is a valid license from spdx
+	 * Checks that the license is a valid license from spdx
 	 *
 	 * @param string $tag
 	 * @param string $next
 	 * @param string $license
-	 * @return boolean
+	 *
+	 * @return void
 	 */
 	private function handleInvalidLicense($tag, $next, $license) {
 		// Initialize the spdx license validator
@@ -273,7 +303,7 @@ class LicenseCommentSniff implements Sniff {
 			}
 		}
 
-		// handle fixable license problem
+		// Handle fixable license problem
 		if ($fixable !== null) {
 			$fix = $this->file->addFixableWarning(
 				'Invalid SPDX license identifier "%s", see <https://spdx.org/licenses/>',
@@ -287,7 +317,7 @@ class LicenseCommentSniff implements Sniff {
 			return;
 		}
 
-		// report un-fixable problems
+		// Report un-fixable problems
 		$this->file->addWarning(
 			'Invalid SPDX license identifier "%s", see <https://spdx.org/licenses/>',
 			$tag,

--- a/HydraWiki/Sniffs/WhiteSpace/NoSpaceAfterNotSniff.php
+++ b/HydraWiki/Sniffs/WhiteSpace/NoSpaceAfterNotSniff.php
@@ -9,9 +9,9 @@
  *
  * Ensures there is no space after a NOT operator.
  *
- * @package PHP_CodeSniffer
- * @author Greg Sherwood <gsherwood@squiz.net>
- * @author Samuel Hilson <shhilson@curse.com>
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Samuel Hilson <shhilson@curse.com>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD-3-Clause
  */
@@ -45,9 +45,9 @@ class NoSpaceAfterNotSniff implements Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param File $phpcsFile The file being scanned.
-	 * @param int $stackPtr The position of the current token in
-	 *                        the stack passed in $tokens.
+	 * @param File    $phpcsFile The file being scanned.
+	 * @param integer $stackPtr  The position of the current token in
+	 *                             the stack passed in $tokens.
 	 *
 	 * @return void
 	 */

--- a/HydraWiki/Sniffs/WhiteSpace/SpaceBeforeSingleLineCommentSniff.php
+++ b/HydraWiki/Sniffs/WhiteSpace/SpaceBeforeSingleLineCommentSniff.php
@@ -3,17 +3,17 @@
  * Curse Inc.
  * SpaceBeforeSingleLineCommentSniff
  *
- * Verify comments are preceeded by a single space.
+ * Verify comments are preceded by a single space.
  *
  * This file was copied from MediaWiki Codesniffer before being modified
  * File: MediaWiki/Sniffs/WhiteSpace/SpaceBeforeSingleLineCommentSniff.php
  * From repository: https://github.com/wikimedia/mediawiki-tools-codesniffer
  *
- * @package	HydraWiki
- * @author Dieser Benutzer
- * @author Samuel Hilson <shhilson@curse.com>
+ * @package   HydraWiki
+ * @author    Dieser Benutzer
+ * @author    Samuel Hilson <shhilson@curse.com>
  * @copyright https://github.com/wikimedia/mediawiki-tools-codesniffer/blob/master/COPYRIGHT
- * @license https://github.com/wikimedia/mediawiki-tools-codesniffer/blob/master/LICENSE GPL-2.0-or-later
+ * @license   https://github.com/wikimedia/mediawiki-tools-codesniffer/blob/master/LICENSE GPL-2.0-or-later
  */
 
 namespace HydraWiki\Sniffs\WhiteSpace;
@@ -24,15 +24,20 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 class SpaceBeforeSingleLineCommentSniff implements Sniff {
 
 	/**
-	 * @inheritDoc
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
 	 */
 	public function register() {
 		return [T_COMMENT];
 	}
 
 	/**
-	 * @param File $phpcsFile
-	 * @param int $stackPtr The current token index.
+	 * Process the file
+	 *
+	 * @param File    $phpcsFile
+	 * @param integer $stackPtr  The current token index.
+	 *
 	 * @return void
 	 */
 	public function process(File $phpcsFile, $stackPtr) {
@@ -76,6 +81,7 @@ class SpaceBeforeSingleLineCommentSniff implements Sniff {
 	 * Check contents of current token for empty state
 	 *
 	 * @param array $currToken
+	 *
 	 * @return boolean
 	 */
 	private function isEmptyComment($currToken) {
@@ -89,6 +95,7 @@ class SpaceBeforeSingleLineCommentSniff implements Sniff {
 	 * Check contents of current token for doc block
 	 *
 	 * @param array $currToken
+	 *
 	 * @return boolean
 	 */
 	private function isDocBlockComment($currToken) {
@@ -103,6 +110,7 @@ class SpaceBeforeSingleLineCommentSniff implements Sniff {
 	 * Check if current token is a comment token
 	 *
 	 * @param [type] $currToken
+	 *
 	 * @return boolean
 	 */
 	private function isComment($currToken) {
@@ -110,11 +118,12 @@ class SpaceBeforeSingleLineCommentSniff implements Sniff {
 	}
 
 	/**
-	 * handle any double slash  style'//' comments
+	 * Handle any double slash  style'//' comments
 	 *
-	 * @param File $phpcsFile
-	 * @param int $stackPtr
-	 * @param array $currToken
+	 * @param File    $phpcsFile
+	 * @param integer $stackPtr
+	 * @param array   $currToken
+	 *
 	 * @return void
 	 */
 	private function handleDoubleSlashComment($phpcsFile, $stackPtr, $currToken) {
@@ -135,11 +144,12 @@ class SpaceBeforeSingleLineCommentSniff implements Sniff {
 	}
 
 	/**
-	 * handle any hash style '#' comments
+	 * Handle any hash style '#' comments
 	 *
-	 * @param File $phpcsFile
-	 * @param int $stackPtr
-	 * @param array $currToken
+	 * @param File    $phpcsFile
+	 * @param integer $stackPtr
+	 * @param array   $currToken
+	 *
 	 * @return void
 	 */
 	private function handleHashComment($phpcsFile, $stackPtr, $currToken) {

--- a/HydraWiki/ruleset.xml
+++ b/HydraWiki/ruleset.xml
@@ -6,6 +6,20 @@
 		<exclude name="MediaWiki.WhiteSpace.SpaceyParenthesis" />
 		<exclude name="MediaWiki.WhiteSpace.SpaceBeforeSingleLineComment" />
 		<exclude name="MediaWiki.Commenting.LicenseComment" />
+		<exclude name="MediaWiki.Commenting.FunctionComment" />
+	</rule>
+	<rule ref="Generic.Commenting" />
+	<rule ref="Squiz.Commenting">
+		<!-- Remove the more annoying requirements -->
+		<exclude name="Squiz.Commenting.ClassComment.Missing" />
+		<exclude name="Squiz.Commenting.ClosingDeclarationComment" />
+		<exclude name="Squiz.Commenting.FileComment" />
+		<exclude name="Squiz.Commenting.FunctionComment.TypeHintMissing" />
+		<exclude name="Squiz.Commenting.FunctionComment.ScalarTypeHintMissing" />
+		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment" />
+		<exclude name="Squiz.Commenting.PostStatementComment" />
+		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
+		<exclude name="Squiz.Commenting.InlineComment.SpacingBefore" />
 	</rule>
 	<!-- Make tab idents checkable and fixable -->
 	<arg name="tab-width" value="4"/>

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ How to install
     ```
     {
     	"require-dev": {
-    		"hydrawiki/hydrawiki-codesniffer": "1.0.0"
+    		"hydrawiki/hydrawiki-codesniffer": "1.0.9"
     	},
     	"scripts": {
     		"test": [

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -7,9 +7,18 @@ use PHP_CodeSniffer\Files\File;
 use PHPUnit\Framework\TestCase;
 
 class BaseTest extends TestCase {
-
+	/**
+	 * Container for the File Mock class
+	 *
+	 * @var File
+	 */
 	protected $fileMock;
 
+	/**
+	 * Setup the mock classes for test
+	 *
+	 * @return void
+	 */
 	protected function setUp() {
 		$this->fileMock = $this->createMock(File::class);
 		$fixer = $this->createMock(Fixer::class);

--- a/tests/Unit/Arrays/NoExtraSpacesSingleLineSniffTest.php
+++ b/tests/Unit/Arrays/NoExtraSpacesSingleLineSniffTest.php
@@ -6,6 +6,11 @@ use Test\BaseTest;
 use HydraWiki\Sniffs\Arrays\NoExtraSpacesSingleLineSniff;
 
 class NoExtraSpacesSingleLineSniffTest extends BaseTest {
+	/**
+	 * Container for the sniff under test
+	 *
+	 * @var NoExtraSpacingSingleLineSniff
+	 */
 	protected $sniff;
 
 	/**
@@ -21,6 +26,7 @@ class NoExtraSpacesSingleLineSniffTest extends BaseTest {
 
 	/**
 	 * Test Sniff with a good array
+	 *
 	 * @covers NoSpaceAfterNotSniff::process
 	 *
 	 * @return void
@@ -110,6 +116,7 @@ class NoExtraSpacesSingleLineSniffTest extends BaseTest {
 
 	/**
 	 * Test Sniff with a bad array
+	 *
 	 * @covers NoSpaceAfterNotSniff::process
 	 *
 	 * @return void
@@ -216,6 +223,7 @@ class NoExtraSpacesSingleLineSniffTest extends BaseTest {
 
 	/**
 	 * Test Sniff with a bad array
+	 *
 	 * @covers NoSpaceAfterNotSniff::process
 	 *
 	 * @return void

--- a/tests/Unit/Commenting/LicenseCommentSniffTest.php
+++ b/tests/Unit/Commenting/LicenseCommentSniffTest.php
@@ -7,7 +7,18 @@ use Composer\Spdx\SpdxLicenses;
 use HydraWiki\Sniffs\Commenting\LicenseCommentSniff;
 
 class LicenseCommentSniffTest extends BaseTest {
+	/**
+	 * Container for the sniff under test
+	 *
+	 * @var LicenseCommentSniff
+	 */
 	protected $sniff;
+
+	/**
+	 * Container for the SpdxLicenses class
+	 *
+	 * @var SpdxLicense
+	 */
 	protected $spdxMock;
 
 	/**
@@ -27,6 +38,7 @@ class LicenseCommentSniffTest extends BaseTest {
 
 	/**
 	 * Test sniff with invalid license
+	 *
 	 * @covers NoSpaceAfterNotSniff::process
 	 * @return void
 	 */
@@ -87,6 +99,7 @@ class LicenseCommentSniffTest extends BaseTest {
 
 	/**
 	 * Test sniff with a valid license
+	 *
 	 * @covers NoSpaceAfterNotSniff::process
 	 * @return void
 	 */
@@ -145,6 +158,7 @@ class LicenseCommentSniffTest extends BaseTest {
 
 	/**
 	 * Test sniff with a Deprecated license
+	 *
 	 * @covers NoSpaceAfterNotSniff::process
 	 * @return void
 	 */

--- a/tests/Unit/WhiteSpace/NoSpaceAfterNotSniffTest.php
+++ b/tests/Unit/WhiteSpace/NoSpaceAfterNotSniffTest.php
@@ -6,6 +6,11 @@ use Test\BaseTest;
 use HydraWiki\Sniffs\WhiteSpace\NoSpaceAfterNotSniff;
 
 class NoSpaceAfterNotSniffTest extends BaseTest {
+	/**
+	 * Container for sniff under test
+	 *
+	 * @var NoSpaceAfterNotSniff
+	 */
 	protected $sniff;
 
 	/**
@@ -20,7 +25,8 @@ class NoSpaceAfterNotSniffTest extends BaseTest {
 	}
 
 	/**
-	 * test sniff when no whitespace is present
+	 * Test sniff when no whitespace is present
+	 *
 	 * @covers NoSpaceAfterNotSniff::process
 	 * @return void
 	 */
@@ -37,7 +43,8 @@ class NoSpaceAfterNotSniffTest extends BaseTest {
 	}
 
 	/**
-	 * test sniff when whitespace is present
+	 * Test sniff when whitespace is present
+	 *
 	 * @covers NoSpaceAfterNotSniff::process
 	 * @return void
 	 */
@@ -59,7 +66,8 @@ class NoSpaceAfterNotSniffTest extends BaseTest {
 	}
 
 	/**
-	 * test sniff when whitespace is present
+	 * Test sniff when whitespace is present
+	 *
 	 * @covers NoSpaceAfterNotSniff::process
 	 * @return void
 	 */

--- a/tests/Unit/WhiteSpace/SpaceBeforeSingleLineCommentSniffTest.php
+++ b/tests/Unit/WhiteSpace/SpaceBeforeSingleLineCommentSniffTest.php
@@ -6,6 +6,11 @@ use Test\BaseTest;
 use HydraWiki\Sniffs\WhiteSpace\SpaceBeforeSingleLineCommentSniff;
 
 class SpaceBeforeSingleLineCommentSniffTest extends BaseTest {
+	/**
+	 * Container for sniff under test
+	 *
+	 * @var SpaceBeforeSingleLineCommentSniff
+	 */
 	protected $sniff;
 
 	/**
@@ -20,7 +25,8 @@ class SpaceBeforeSingleLineCommentSniffTest extends BaseTest {
 	}
 
 	/**
-	 * test sniff with correctly formatted comment starting with '//'
+	 * Test sniff with correctly formatted comment starting with '//'
+	 *
 	 * @covers SpaceBeforeSingleLineCommentSniff::process
 	 *
 	 * @return void
@@ -57,6 +63,7 @@ class SpaceBeforeSingleLineCommentSniffTest extends BaseTest {
 
 	/**
 	 * Test sniff with correctly formatted comment starting with '#'
+	 *
 	 * @covers SpaceBeforeSingleLineCommentSniff::process
 	 *
 	 * @return void
@@ -93,6 +100,7 @@ class SpaceBeforeSingleLineCommentSniffTest extends BaseTest {
 
 	/**
 	 * Test sniff with comment at the end of a line of code
+	 *
 	 * @covers SpaceBeforeSingleLineCommentSniff::process
 	 *
 	 * @return void
@@ -134,6 +142,7 @@ class SpaceBeforeSingleLineCommentSniffTest extends BaseTest {
 
 	/**
 	 * Test sniff with incorrectly formatted comment starting with '//'
+	 *
 	 * @covers SpaceBeforeSingleLineCommentSniff::process
 	 *
 	 * @return void
@@ -160,7 +169,7 @@ class SpaceBeforeSingleLineCommentSniffTest extends BaseTest {
 		$this->fileMock->expects($this->exactly(0))
 			->method('addWarning');
 
-		// test that a fixable warning is created.
+		// Test that a fixable warning is created.
 		$this->fileMock->expects($this->once())
 			->method('addFixableWarning')
 			->with(
@@ -170,7 +179,7 @@ class SpaceBeforeSingleLineCommentSniffTest extends BaseTest {
 			)
 			->willReturn(true);
 
-		// test that the coment is fixed.
+		// Test that the comment is fixed.
 		$this->fileMock->fixer->expects($this->once())
 			->method('replaceToken')
 			->with(
@@ -185,6 +194,7 @@ class SpaceBeforeSingleLineCommentSniffTest extends BaseTest {
 
 	/**
 	 * Test sniff with incorrectly formatted comment starting with '#'
+	 *
 	 * @covers SpaceBeforeSingleLineCommentSniff::process
 	 *
 	 * @return void
@@ -211,7 +221,7 @@ class SpaceBeforeSingleLineCommentSniffTest extends BaseTest {
 		$this->fileMock->expects($this->exactly(0))
 			->method('addWarning');
 
-		// test that a fixable warning is created.
+		// Test that a fixable warning is created.
 		$this->fileMock->expects($this->once())
 			->method('addFixableWarning')
 			->with(
@@ -221,7 +231,7 @@ class SpaceBeforeSingleLineCommentSniffTest extends BaseTest {
 			)
 			->willReturn(true);
 
-		// test that the coment is fixed.
+		// Test that the comment is fixed.
 		$this->fileMock->fixer->expects($this->once())
 			->method('replaceToken')
 			->with(
@@ -236,6 +246,7 @@ class SpaceBeforeSingleLineCommentSniffTest extends BaseTest {
 
 	/**
 	 * Test sniff comment from doc block
+	 *
 	 * @covers SpaceBeforeSingleLineCommentSniff::process
 	 *
 	 * @return void
@@ -272,6 +283,7 @@ class SpaceBeforeSingleLineCommentSniffTest extends BaseTest {
 
 	/**
 	 * Test sniff with an empty comment
+	 *
 	 * @covers SpaceBeforeSingleLineCommentSniff::process
 	 *
 	 * @return void


### PR DESCRIPTION
Replacing Mediawiki commenting standards with Squiz.
Applying standards to codebase